### PR TITLE
Fix Twitter and Discord swapped links

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -232,7 +232,7 @@ const Landing = () => (
 					</a>
 				</Link>
 				{navigation.map(item => (
-					<a className="font-medium" href={item.href} target="_blank" rel="noopener noreferrer">
+					<a key={item.name} className="font-medium" href={item.href} target="_blank" rel="noopener noreferrer">
 						{item.name}
 					</a>
 				))}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -231,22 +231,11 @@ const Landing = () => (
 						Hyperscale
 					</a>
 				</Link>
-				<a
-					className="font-medium"
-					href="https://twitter.com/HyperscaleFund"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					Twitter
-				</a>
-				<a
-					className="font-medium"
-					href="https://discord.com/invite/pVSbzYny2c"
-					target="_blank"
-					rel="noopener noreferrer"
-				>
-					Discord
-				</a>
+				{navigation.map(item => (
+					<a className="font-medium" href={item.href} target="_blank" rel="noopener noreferrer">
+						{item.name}
+					</a>
+				))}
 			</div>
 			<div>
 				<a


### PR DESCRIPTION
 swap + improvement to avoid updating two places with the links (please note that we have Twitter/Discord on top and bottom of the website.
