### PR TITLE
Underline Fast and early in the title

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -148,9 +148,8 @@ const Landing = () => (
 					<div className="lg:grid lg:grid-cols-12 lg:gap-8">
 						<div className="sm:text-center md:max-w-2xl md:mx-auto lg:col-span-6 lg:text-left">
 							<h1>
-								<span className="mt-1 block text-4xl tracking-tight font-extrabold sm:text-5xl xl:text-6xl">
-									<span className="block text-indigo-400">Fast funding</span>
-									<span className="block text-gray-900">for early blockchain projects</span>
+								<span className="mt-1 block text-gray-900 text-4xl tracking-tight font-extrabold sm:text-5xl xl:text-6xl">
+									<span className="underlined">Fast</span> funding for <span className="underlined">early</span> blockchain projects
 								</span>
 							</h1>
 							<p className="mt-3 text-base text-gray-500 sm:mt-5 sm:text-xl lg:text-lg xl:text-xl">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -32,9 +32,13 @@
     }
 }
 
-  @font-face {
+@font-face {
     font-family: Redrose;
     font-style: normal;
     font-display: swap;
     src: local('Redrose'), url('/RedRose.ttf') format('ttf');
-  }
+}
+
+.underlined {
+  background: linear-gradient(#FFD17F, #FFD17F) 0 var(--y-pos, 90%) / 100% var(--size, 12px) no-repeat;
+}


### PR DESCRIPTION
As per design `Fast` and `early` words in the title have yellow
underline.

Before:
![screenshot-2021-12-07-12:53:32](https://user-images.githubusercontent.com/3427904/145032922-786c57a3-6563-4395-bdcd-918fc6c4afbf.png)
After:
![screenshot-2021-12-07-12:53:11](https://user-images.githubusercontent.com/3427904/145032943-917521c8-f313-4173-8421-e1dd5b406d53.png)
