### PR TITLE
Fix color and remove background image

### DIFF
--- a/src/pages/privacy.js
+++ b/src/pages/privacy.js
@@ -23,19 +23,12 @@ export async function getStaticProps() {
 }
 
 const Privacy = ({ privacyHtml }) => (
-	<div>
-		<div
-			className="bg-no-repeat bg-cover bg-[#1602AS] pb-16 px-6 md:px-10"
-			style={{ backgroundImage: "url('./section1/background.svg')" }}
-		>
-			<Header />
-			<div className="bg-[#160A2F] md:p-8 relative">
-				<div className="container mx-auto pt-8 xl:px-32">
-					<div className="container mx-auto bg-[#EBE8E3] rounded py-24 px-4 sm:px-10 xl:px-32">
-						<h2 className="font-redrose text-5xl pb-12">Privacy Policy</h2>
-						<div className="markdown" dangerouslySetInnerHTML={{ __html: privacyHtml }} />
-					</div>
-				</div>
+	<div className="bg-[#160A2F] md:p-8 relative">
+		<Header />
+		<div className="container mx-auto pt-8 xl:px-32">
+			<div className="container mx-auto bg-[#EBE8E3] rounded py-24 px-4 sm:px-10 xl:px-32">
+				<h2 className="font-redrose text-5xl pb-12">Privacy Policy</h2>
+				<div className="markdown" dangerouslySetInnerHTML={{ __html: privacyHtml }} />
 			</div>
 		</div>
 		<Footer />

--- a/src/pages/privacy.js
+++ b/src/pages/privacy.js
@@ -23,12 +23,16 @@ export async function getStaticProps() {
 }
 
 const Privacy = ({ privacyHtml }) => (
-	<div className="bg-[#160A2F] md:p-8 relative">
-		<Header />
-		<div className="container mx-auto pt-8 xl:px-32">
-			<div className="container mx-auto bg-[#EBE8E3] rounded py-24 px-4 sm:px-10 xl:px-32">
-				<h2 className="font-redrose text-5xl pb-12">Privacy Policy</h2>
-				<div className="markdown" dangerouslySetInnerHTML={{ __html: privacyHtml }} />
+	<div>
+		<div className="bg-no-repeat bg-cover bg-[#160A2F] pb-16 px-6 md:px-10">
+			<Header />
+			<div className="bg-[#160A2F] md:p-8 relative">
+				<div className="container mx-auto pt-8 xl:px-32">
+					<div className="container mx-auto bg-[#EBE8E3] rounded py-24 px-4 sm:px-10 xl:px-32">
+						<h2 className="font-redrose text-5xl pb-12">Privacy Policy</h2>
+						<div className="markdown" dangerouslySetInnerHTML={{ __html: privacyHtml }} />
+					</div>
+				</div>
 			</div>
 		</div>
 		<Footer />

--- a/src/pages/terms.js
+++ b/src/pages/terms.js
@@ -21,19 +21,12 @@ export async function getStaticProps() {
 }
 
 const Terms = ({ termsHtml }) => (
-	<div>
-		<div
-			className="bg-no-repeat bg-cover bg-[#1602AS] pb-16 px-6 md:px-10"
-			style={{ backgroundImage: "url('./section1/background.svg')" }}
-		>
-			<Header />
-			<div className="bg-[#160A2F] md:p-8 relative">
-				<div className="container mx-auto pt-8 xl:px-32">
-					<div className="container mx-auto bg-[#EBE8E3] rounded py-24 px-4 sm:px-10 xl:px-32">
-						<h2 className="font-redrose text-5xl pb-12">Terms of Use</h2>
-						<div className="markdown" dangerouslySetInnerHTML={{ __html: termsHtml }} />
-					</div>
-				</div>
+	<div className="bg-[#160A2F] md:p-8 relative">
+		<Header />
+		<div className="container mx-auto pt-8 xl:px-32">
+			<div className="container mx-auto bg-[#EBE8E3] rounded py-24 px-4 sm:px-10 xl:px-32">
+				<h2 className="font-redrose text-5xl pb-12">Terms of Use</h2>
+				<div className="markdown" dangerouslySetInnerHTML={{ __html: termsHtml }} />
 			</div>
 		</div>
 		<Footer />

--- a/src/pages/terms.js
+++ b/src/pages/terms.js
@@ -21,12 +21,16 @@ export async function getStaticProps() {
 }
 
 const Terms = ({ termsHtml }) => (
-	<div className="bg-[#160A2F] md:p-8 relative">
-		<Header />
-		<div className="container mx-auto pt-8 xl:px-32">
-			<div className="container mx-auto bg-[#EBE8E3] rounded py-24 px-4 sm:px-10 xl:px-32">
-				<h2 className="font-redrose text-5xl pb-12">Terms of Use</h2>
-				<div className="markdown" dangerouslySetInnerHTML={{ __html: termsHtml }} />
+	<div className="bg-no-repeat bg-cover bg-[#160A2F] pb-16 px-6 md:px-10">
+		<div>
+			<Header />
+			<div className="bg-[#160A2F] md:p-8 relative">
+				<div className="container mx-auto pt-8 xl:px-32">
+					<div className="container mx-auto bg-[#EBE8E3] rounded py-24 px-4 sm:px-10 xl:px-32">
+						<h2 className="font-redrose text-5xl pb-12">Terms of Use</h2>
+						<div className="markdown" dangerouslySetInnerHTML={{ __html: termsHtml }} />
+					</div>
+				</div>
 			</div>
 		</div>
 		<Footer />


### PR DESCRIPTION
Removes the background image from the privacy and terms page. Also corrects a typo in the color hex code.

https://trello.com/c/qDphmKLs/17-terms-privacy-pages-remove-background-image-and-and-set-bg-1602as