### PR TITLE
Refactor links

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,15 +1,5 @@
 import Link from 'next/link'
-
-const text = 'Hyperscale'
-const separator = '//'
-const links = [
-	'https://hyperscale.notion.site/Hyperscale-Knowledge-Base-6c8253dc64df4562bf4f258bbd206707',
-	'https://www.twitter.com/HyperscaleFund',
-	'https://discord.gg/7CGPQ8fWHt',
-	'https://airtable.com/shrLFCXD7BQXUg97K',
-	'/privacy',
-	'/terms',
-]
+import links from '../lib/links'
 
 const Footer = () => (
 	<div className="w-full bg-[#160A2F] px-8">
@@ -18,27 +8,27 @@ const Footer = () => (
 				<img src="/footer/Footer-logo.svg" className="w-40 lg:w-min" />
 			</div>
 			<div className="w-full lg:w-auto flex justify-evenly lg:justify-end pb-8 lg:pb-0 font-light text-white/70">
-				<Link href={links[0]}>
-					<a className="mx-4">
+				<Link href={links.knowledgeBase}>
+					<a className="mx-4" target="_blank">
 						<div className="">FAQ</div>
 					</a>
 				</Link>
-				<Link href={links[1]}>
+				<Link href={links.twitter}>
 					<a className="mx-4" target="_blank">
 						<div className="">Twitter</div>
 					</a>
 				</Link>
-				<Link href={links[2]}>
+				<Link href={links.discord}>
 					<a className="mx-4" target="_blank">
 						<div className="">Discord</div>
 					</a>
 				</Link>
-				<Link href={links[4]}>
+				<Link href={links.privacy}>
 					<a className="mx-4 hidden lg:block">
 						<div className="">Privacy Policy</div>
 					</a>
 				</Link>
-				<Link href={links[5]}>
+				<Link href={links.terms}>
 					<a className="mx-4 hidden lg:block">
 						<div className="">Terms of Service</div>
 					</a>
@@ -46,12 +36,12 @@ const Footer = () => (
 			</div>
 			{/* Mobile only */}
 			<div className="w-full flex justify-evenly lg:hidden text-xs text-white/70 mt-8">
-				<Link href={links[4]}>
+				<Link href={links.privacy}>
 					<a className="">
 						<div className="">Privacy Policy</div>
 					</a>
 				</Link>
-				<Link href={links[5]}>
+				<Link href={links.terms}>
 					<a className="">
 						<div className="">Terms of Service</div>
 					</a>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,13 +3,7 @@ import Image from 'next/image'
 import { Popover, Transition } from '@headlessui/react'
 import { MenuIcon, XIcon } from '@heroicons/react/outline'
 import { Fragment } from 'react'
-
-const links = [
-	'https://www.twitter.com/HyperscaleFund',
-	'https://discord.gg/7CGPQ8fWHt',
-	'https://airtable.com/shrLFCXD7BQXUg97K',
-	'https://hyperscale.notion.site/Hyperscale-Knowledge-Base-6c8253dc64df4562bf4f258bbd206707',
-]
+import links from '../lib/links'
 
 const Header = () => (
 	<nav className="w-full z-30">
@@ -21,22 +15,22 @@ const Header = () => (
 			</Link>
 			{/* Desktop Navigation */}
 			<div className="hidden lg:flex md:items-center space-x-0 text-redrose">
-				<Link href={links[3]}>
+				<Link href={links.knowledgeBase}>
 					<a target="_blank">
 						<div className="text-white mr-8 lg:mr-16">Knowledge Base</div>
 					</a>
 				</Link>
-				<Link href={links[0]}>
+				<Link href={links.twitter}>
 					<a target="_blank">
 						<div className="text-white mr-8 lg:mr-16">Twitter</div>
 					</a>
 				</Link>
-				<Link href={links[1]}>
+				<Link href={links.discord}>
 					<a target="_blank">
 						<div className="text-white mr-8 lg:mr-16">Discord</div>
 					</a>
 				</Link>
-				<Link href={links[2]}>
+				<Link href={links.apply}>
 					<a target="_blank">
 						<div className="flex w-24 h-10 bg-[#BAC4FA] rounded-sm justify-center items-center font-semibold">
 							Apply
@@ -82,28 +76,28 @@ const Header = () => (
 							</div>
 						</div>
 						<div className="px-2 pt-2 pb-3 space-y-1">
-							<Link href={links[3]}>
+							<Link href={links.knowledgeBase}>
 								<a target="_blank">
 									<div className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50">
 										Knowledge base
 									</div>
 								</a>
 							</Link>
-							<Link href={links[0]}>
+							<Link href={links.twitter}>
 								<a target="_blank">
 									<div className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50">
 										Twitter
 									</div>
 								</a>
 							</Link>
-							<Link href={links[1]}>
+							<Link href={links.discord}>
 								<a target="_blank">
 									<div className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-50">
 										Discord
 									</div>
 								</a>
 							</Link>
-							<Link href={links[2]}>
+							<Link href={links.apply}>
 								<a target="_blank">
 									<div className="offset-border block w-56 border-black rounded bg-[#BAC4FA] py-2 px-6 text-lg font-semibold">
 										Apply to Hyperscale

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -22,7 +22,7 @@ const Header = () => (
 			{/* Desktop Navigation */}
 			<div className="hidden lg:flex md:items-center space-x-0 text-redrose">
 				<Link href={links[3]}>
-					<a>
+					<a target="_blank">
 						<div className="text-white mr-8 lg:mr-16">Knowledge Base</div>
 					</a>
 				</Link>

--- a/src/components/Section1.js
+++ b/src/components/Section1.js
@@ -1,12 +1,8 @@
 import Link from 'next/link'
 import Header from '../components/Header'
+import links from "../lib/links.js":
 
 const text = 'Receive up to $1M in funding and the benefits of the Hyperscale ecosystem in a matter of days.'
-const links = [
-	'https://www.twitter.com/HyperscaleFund',
-	'https://discord.gg/7CGPQ8fWHt',
-	'https://airtable.com/shrLFCXD7BQXUg97K',
-]
 
 const Section1 = () => (
 	<div className=" bg-[#160A2F] pb-8 px-6 md:px-10 bg-curvature">
@@ -17,7 +13,7 @@ const Section1 = () => (
 					An ecosystem of <span className="hs-gradient">web3</span> projects
 				</h1>
 				<div className="text-white text- md:text-xl lg: my-6 md:my-12">{text}</div>
-				<Link href={links[2]}>
+				<Link href={links.apply}>
 					<a target="_blank">
 						<div className="flex w-24 h-10 bg-[#BAC4FA] rounded-sm justify-center items-center font-semibold">
 							Apply

--- a/src/components/Section1.js
+++ b/src/components/Section1.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import Header from '../components/Header'
-import links from "../lib/links.js":
+import links from '../lib/links.js'
 
 const text = 'Receive up to $1M in funding and the benefits of the Hyperscale ecosystem in a matter of days.'
 

--- a/src/components/Section2.js
+++ b/src/components/Section2.js
@@ -1,10 +1,7 @@
 import Link from 'next/link'
+import links from '../lib/links'
 
 const text = 'Hyperscale DAO helps you build and grow your project.'
-const links = [
-	'https://airtable.com/shrLFCXD7BQXUg97K',
-	'https://hyperscale.notion.site/Hyperscale-Knowledge-Base-6c8253dc64df4562bf4f258bbd206707',
-]
 
 const Section2 = () => (
 	<div className="relative bg-[#160A2F]">
@@ -46,14 +43,14 @@ const Section2 = () => (
 							</div>
 						</div>
 					</div>
-					<Link href={links[0]}>
+					<Link href={links.apply}>
 						<a target="_blank">
 							<div className="offset-border border-black rounded bg-[#BAC4FA] py-2 px-6 text-lg font-semibold">
 								Apply to Hyperscale
 							</div>
 						</a>
 					</Link>
-					<Link href={links[1]}>
+					<Link href={links.knowledgeBase}>
 						<a target="_blank">
 							<div className="mt-6 py-2 px-6 text-lg">Learn more</div>
 						</a>

--- a/src/components/Section5.js
+++ b/src/components/Section5.js
@@ -1,7 +1,7 @@
 import Link from 'next/link'
+import links from '../lib/links'
 
 const text = 'Receive up to $1M funding. Apply in 15 minutes and you’ll recieve a decision within a few days'
-const links = ['https://airtable.com/shrLFCXD7BQXUg97K']
 
 const Section5 = () => (
 	<div className="bg-no-repeat bg-cover" style={{ backgroundImage: "url('/section5/14-Final-section-BG.jpg')" }}>
@@ -11,7 +11,7 @@ const Section5 = () => (
 			<img src="/coins/token5.svg" className="lg:absolute -top-12 pb-12 md:top-0 md:right-0" />
 			<h2 className="font-redrose text-gray-100 text-4xl font-bold">Apply to Hyperscale</h2>
 			<div className="text-white text-xl my-12 text-center w-96">{text}</div>
-			<Link href={links[0]}>
+			<Link href={links.apply}>
 				<a target="_blank">
 					<div className="offset-border flex px-6 py-2 bg-[#FEDB9E] rounded justify-center items-center font-semibold">
 						Apply to Hyperscale

--- a/src/lib/links.js
+++ b/src/lib/links.js
@@ -1,6 +1,10 @@
 const links = {
-	faq: 'https://hyperscale.notion.site/Hyperscale-Knowledge-Base-6c8253dc64df4562bf4f258bbd206707',
-	header: 'https://hyperscale.notion.site/Hyperscale-Knowledge-Base-6c8253dc64df4562bf4f258bbd206707',
+	knowledgeBase: 'https://hyperscale.notion.site/Hyperscale-Knowledge-Base-6c8253dc64df4562bf4f258bbd206707',
+	twitter: 'https://www.twitter.com/HyperscaleFund',
+	discord: 'https://discord.gg/7CGPQ8fWHt',
+	apply: 'https://airtable.com/shrLFCXD7BQXUg97K',
+	privacy: '/privacy',
+	terms: '/terms',
 }
 
 export default links

--- a/src/lib/links.js
+++ b/src/lib/links.js
@@ -1,0 +1,6 @@
+const links = {
+	faq: 'https://hyperscale.notion.site/Hyperscale-Knowledge-Base-6c8253dc64df4562bf4f258bbd206707',
+	header: 'https://hyperscale.notion.site/Hyperscale-Knowledge-Base-6c8253dc64df4562bf4f258bbd206707',
+}
+
+export default links


### PR DESCRIPTION
Refactors all links to `lib/links.js` to avoid unneeded component repetition, and uses an object instead of an array to be more descriptive.

Also fixes knowledge base not opening in new tab in footer, or in header on desktop.